### PR TITLE
upgrade to python 3.11 and gdal 3.8.3 via lambgeo/docker-lambda

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -17,10 +17,6 @@ inputs:
     required: true
   PRODUCT_PATH:
     required: true
-  GDAL_LAYER_ARN:
-    required: true
-  GDAL_DATA_PATH:
-    required: true
   URS_HOSTNAME:
     required: true
   URS_USERNAME:
@@ -47,7 +43,7 @@ runs:
 
     - shell: bash
       run: |
-        pip install -r requirements-reformat.txt -t reformat/src/
+        ./build_deployment_package.sh
         sed "s/REPLACEME/$(openssl rand -hex 4)/" cloudformation.yml > cloudformation-replaced.yml
         aws cloudformation package \
           --template-file cloudformation-replaced.yml \
@@ -64,8 +60,6 @@ runs:
             LogPrefix="${{ inputs.LOG_PREFIX }}" \
             StorageExpirationInDays="${{ inputs.STORAGE_EXPIRATION_IN_DAYS }}" \
             ProductPath="${{ inputs.PRODUCT_PATH }}" \
-            GdalLayerArn="${{ inputs.GDAL_LAYER_ARN }}" \
-            GdalDataPath="${{ inputs.GDAL_DATA_PATH }}" \
             UrsHostname="${{ inputs.URS_HOSTNAME }}" \
             UrsUsername="${{ inputs.URS_USERNAME }}" \
             UrsPassword="${{ inputs.URS_PASSWORD }}" \

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -26,8 +26,6 @@ jobs:
           LOG_PREFIX: s3-access/
           STORAGE_EXPIRATION_IN_DAYS: 1
           PRODUCT_PATH: https://grfn.asf.alaska.edu/door/download/
-          GDAL_LAYER_ARN: ${{ secrets.GDAL_LAYER_ARN }}
-          GDAL_DATA_PATH: /opt/lib/data
           URS_HOSTNAME: urs.earthdata.nasa.gov
           URS_USERNAME: ${{ secrets.URS_USERNAME }}
           URS_PASSWORD: ${{ secrets.URS_PASSWORD }}

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -26,8 +26,6 @@ jobs:
           LOG_PREFIX: s3-access/
           STORAGE_EXPIRATION_IN_DAYS: 1
           PRODUCT_PATH: https://grfn-test.asf.alaska.edu/door/download/
-          GDAL_LAYER_ARN: ${{ secrets.GDAL_LAYER_ARN }}
-          GDAL_DATA_PATH: /opt/lib/data
           URS_HOSTNAME: urs.earthdata.nasa.gov
           URS_USERNAME: ${{ secrets.URS_USERNAME }}
           URS_PASSWORD: ${{ secrets.URS_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+### Changed
+- Upgraded to Python 3.11 and GDAL 3.8.3 via [lambgeo/docker-lambda](https://github.com/lambgeo/docker-lambda)
+
 ## [1.0.0]
 ### Added
 - Versioned releases are now published to GitHub and changes are tracked in CHANGELOG.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ghcr.io/lambgeo/lambda-gdal:3.8-python3.11
+
+ENV INSTALL_DIR=/tmp/deployment_package
+ENV PACKAGE_ZIP=/tmp/package.zip
+
+RUN yum install -y zip
+
+# Install python package and dependencies
+COPY requirements-reformat.txt .
+RUN python -m pip install --no-compile -r requirements-reformat.txt -t $INSTALL_DIR
+
+COPY reformat/src $INSTALL_DIR
+
+# Reduce size of the C libs
+RUN cd $PREFIX && find lib -name \*.so\* -exec strip {} \;
+
+# Add python code to the deployment package
+RUN cd $INSTALL_DIR && zip -r9q $PACKAGE_ZIP *
+
+# Add GDAL libs (in $PREFIX/lib $PREFIX/bin $PREFIX/share) to the deployment package
+RUN cd $PREFIX && zip -r9q --symlinks $PACKAGE_ZIP lib/*.so* share
+RUN cd $PREFIX && zip -r9q --symlinks $PACKAGE_ZIP bin/gdal* bin/ogr* bin/geos* bin/nearblack

--- a/build_deployment_package.sh
+++ b/build_deployment_package.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker build -t packaging-image .
+docker run --name packaging-container -itd packaging-image bash
+docker cp packaging-container:/tmp/package.zip package.zip
+docker stop packaging-container
+docker rm packaging-container

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -18,13 +18,6 @@ Parameters:
     Type: String
     Default: https://grfn.asf.alaska.edu/door/download/
 
-  GdalLayerArn:
-    Type: String
-
-  GdalDataPath:
-    Type: String
-    Default: /opt/lib/data
-
   UrsHostname:
     Type: String
     Default: urs.earthdata.nasa.gov
@@ -106,8 +99,6 @@ Resources:
         Name: !Sub "${AWS::StackName}-reformat"
         Bucket: !Ref Bucket
         ProductPath: !Ref ProductPath
-        GdalLayerArn: !Ref GdalLayerArn
-        GdalDataPath: !Ref GdalDataPath
         SecretArn: !Ref Secret
       TemplateURL: reformat/cloudformation.yml
 

--- a/reformat/cloudformation.yml
+++ b/reformat/cloudformation.yml
@@ -11,13 +11,6 @@ Parameters:
   ProductPath:
     Type: String
 
-  GdalLayerArn:
-    Type: String
-
-  GdalDataPath:
-    Type: String
-    Default: /opt/lib/data
-
   SecretArn:
     Type: String
 
@@ -75,7 +68,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Ref Name
-      Code: src/
+      Code: package.zip
       DeadLetterConfig:
         TargetArn: !GetAtt DeadLetterQueue.Arn
       Environment:
@@ -86,12 +79,11 @@ Resources:
               "product_path": "${ProductPath}",
               "secret_arn": "${SecretArn}"
             }
-          GDAL_DATA: !Ref GdalDataPath
+          GDAL_DATA: /var/task/share/gdal
+          PROJ_LIB: /var/task/share/proj
           HOME: /tmp
       Handler: main.lambda_handler
-      Layers:
-      - !Ref GdalLayerArn
       MemorySize: 3008
       Role: !GetAtt Role.Arn
-      Runtime: python3.8
+      Runtime: python3.11
       Timeout: 30


### PR DESCRIPTION
I've deleted the obsolete GDAL_DATA_PATH secret from the `test` environment. Will delete from the `prod` environment prior to a production release.